### PR TITLE
Add working fixes & findings (touchscreen, Fn keys, fan, fingerprint, battery, S3/camera notes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,23 @@ Fortunately there's a patch for this and other problems.
 
 ### What works (with tweaks)
 
+Working scripts/patches for the items below are collected in [`fixes/`](fixes/).
+
 - :heavy_check_mark: Keyboard, Works with kernel 6.19: [#1](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/1)
-- :heavy_check_mark: Fingerprint Reader, See [#6](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/6)
+- :heavy_check_mark: Fingerprint Reader (FPC 10a5:9924), libfprint patch: [`fixes/fingerprint`](fixes/fingerprint/) — [#6](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/6)
+- :heavy_check_mark: Touchscreen (FocalTech FTSC1000), GPIO power + acpi_call: [`fixes/touchscreen`](fixes/touchscreen/) — [#5](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/5)
+- :heavy_check_mark: Fn Keys, patched huawei-wmi: [`fixes/fn-keys`](fixes/fn-keys/) — [#4](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/4)
+- :heavy_check_mark: Fan speed readout, hwmon module: [`fixes/fan`](fixes/fan/) — [#7](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/7)
+- :heavy_check_mark: Battery charge thresholds (honoured by EC): [`fixes/battery`](fixes/battery/) — [#10](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/10)
+- :heavy_check_mark: Caps-Lock LED (kernel ≥ 7.0) and Mic-mute key LED: [#9](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/9)
+- :heavy_check_mark: Performance profiles via power-profiles-daemon (CPU EPP); Fn+P switches the EC platform mode
+- :heavy_check_mark: Hibernate / suspend-then-hibernate (S4) — works; useful since S3 is unavailable
 
 ### What doesn't work
 
-- :x: Touchscreen, See [#5](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/5)
-- :x: Fn Keys (some), See [#4](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/4)
-- :x: LED on Caps-Lock and Mic key, See [#9](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/9)
-- :x: Fan speed, See: [#7](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/7)
 - :x: Power button, See: [#8](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/8)
-- :x: Respect battery tresholds, See: [#10](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/10)
+- :x: S3 deep sleep — vestigial on Arrow Lake-H (Windows has no S3 either); only s2idle. See [`fixes/README.md`](fixes/README.md)
+- :x: IR camera / face unlock — not present in hardware on the 2025 model (RGB webcam only)
 
 ### Tested Linux Distributions
 
@@ -81,6 +87,11 @@ And reboot.
 
 See: [#3](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/3)
 
+### 4. Other hardware (touchscreen, Fn keys, fan readout, fingerprint, battery)
+
+See the [`fixes/`](fixes/) directory for working scripts, a small hwmon kernel
+module, and patches, each with its own README and install steps.
+
 ## Problems and how to solve them
 
 Have a look at the [Github issues](https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues).
@@ -98,7 +109,9 @@ Family: HONOR MagicBook
 
 ### Latest Bios
 
-BIOS version 1.13 (release date 05/08/2025)
+BIOS version 1.13 (release date 05/08/2025).
+BIOS 1.16 has also been tested — same DSDT bug, the same patched DSDT approach
+applies (the `\_S3` package is likewise present-but-gated; see [`fixes/`](fixes/)).
 
 ### Hardware
 

--- a/fixes/README.md
+++ b/fixes/README.md
@@ -1,0 +1,39 @@
+# Fixes & findings — Honor MagicBook (Pro) 14 (FMB-P)
+
+Tested on a global FMB-P, **BIOS 1.16**, Core Ultra 9 285H (Arrow Lake-H),
+CachyOS, kernel 7.0 (and LTS 6.18). The patched DSDT
+([denis-bb/honor-fmb-p-dsdt](https://github.com/denis-bb/honor-fmb-p-dsdt))
+is assumed to be applied first — it's the prerequisite for most of the below.
+
+| Area | Status | Folder / notes |
+|------|--------|----------------|
+| Touchscreen (FTSC1000) | ✅ working | [`touchscreen/`](touchscreen/) — GPIO power + `acpi_call` + service (issue #5/#20) |
+| Fn keys | ✅ working | [`fn-keys/`](fn-keys/) — patched `huawei-wmi` + hwdb (issue #4) |
+| Fan RPM readout | ✅ working | [`fan/`](fan/) — `honor-fmbp-hwmon` hwmon module (issue #7) |
+| Fingerprint (FPC 10a5:9924) | ✅ working | [`fingerprint/`](fingerprint/) — `libfprint` fpcmoc patch (issue #6) |
+| Battery charge thresholds | ✅ working | [`battery/`](battery/) — honoured by EC; persist service (issue #10/#17) |
+| Caps-Lock LED | ✅ working | kernel ≥ 7.0, no tweak needed (issue #9) |
+| Mic-mute key LED | ✅ working | `platform::micmute` LED toggles correctly (issue #9) |
+| Performance profiles | ✅ working | `power-profiles-daemon` switches CPU EPP (Performance/Balanced/Power-Saver); KDE selector works. Firmware DPTF `platform_profile` is absent ("placeholder"), but Fn+P still switches the EC platform mode. |
+| Suspend (s2idle) | ✅ working | only supported suspend; see S3 finding below |
+| Hibernate / suspend-then-hibernate | ✅ working | S4 hibernate works (e.g. encrypted swapfile + `resume=`); use it for low standby drain since S3 is unavailable |
+
+## Findings (hardware/firmware limits — not fixable in Linux)
+
+- **No S3 deep sleep.** The DSDT contains a valid `\_S3` package but it's gated
+  behind `Name (SS3, Zero)` which the firmware never sets, so only s2idle is
+  offered. Forcing it (override `SS3 = One`) *does* register S3, but entering it
+  **hard-freezes** the machine (no resume). This is expected: Intel removed S3
+  from 11th-gen onward, and Arrow Lake-H implements only S0ix / Modern Standby —
+  **Windows has no S3 on this platform either.** Use hibernate for long idle.
+- **No IR camera / face unlock.** The 2025 FMB-P ships a plain 1080p RGB webcam;
+  the glossy strip by the lens only looks like it houses IR emitters. (Windows
+  Hello face is a 2026-model feature.) Fingerprint is the biometric option.
+
+---
+
+*These fixes and notes were developed and documented with the help of an LLM,
+then validated on real hardware. Treat the out-of-tree modules/patches as
+"works for me today" starting points; upstreaming the relevant bits (huawei-wmi
+keymap, libfprint id + 0x4 identity handling, a proper touchscreen DSDT power
+resource) is the better long-term path.*

--- a/fixes/README.md
+++ b/fixes/README.md
@@ -18,6 +18,11 @@ is assumed to be applied first — it's the prerequisite for most of the below.
 | Suspend (s2idle) | ✅ working | only supported suspend; see S3 finding below |
 | Hibernate / suspend-then-hibernate | ✅ working | S4 hibernate works (e.g. encrypted swapfile + `resume=`); use it for low standby drain since S3 is unavailable |
 
+For *why* each shimmed device needs a shim — the annotated ACPI `_DSM` /
+device-init traces (touchscreen, fingerprint, EC) and the `_OSI`/`OSYS`
+Windows-gating that explains the "works on Windows out of the box" gap — see
+[`acpi-dsm-notes.md`](acpi-dsm-notes.md).
+
 ## Findings (hardware/firmware limits — not fixable in Linux)
 
 - **No S3 deep sleep.** The DSDT contains a valid `\_S3` package but it's gated

--- a/fixes/acpi-dsm-notes.md
+++ b/fixes/acpi-dsm-notes.md
@@ -1,0 +1,211 @@
+# ACPI `_DSM` / device-init notes (FMB-P, BIOS 1.16)
+
+Why this file exists: every device we still drive with an out-of-tree shim
+(touchscreen, fan/EC, fingerprint) was traced back to its ACPI definition to
+answer *"what does Windows do that we don't, and is anything missing?"*. The
+short answer: **nothing is hidden.** Windows reads the same DSDT/SSDTs; it just
+(a) runs a more permissive AML interpreter, (b) takes the `_OSI("Windows …")`
+code path, and (c) ships vendor drivers that carry the per-device knowledge.
+Our fixes are the Linux equivalents of those vendor drivers.
+
+Tables were taken live from `/sys/firmware/acpi/tables/` and decompiled with
+`iasl -d DSDT`. Line numbers below are from that disassembly (BIOS 1.16) and
+will drift between firmware revisions — match on the method/name, not the line.
+
+---
+
+## The OS gate everything hangs off: `OSYS`
+
+`_SB` sets a variable `OSYS` from whichever `_OSI("Windows …")` string answers
+true, then branches on it in **~50 places**:
+
+```asl
+OSYS = 0x03E8                         // default ("no known Windows")
+If (_OSI ("Windows 2015")) { OSYS = 0x07DF }   // + 8 earlier versions
+...
+If ((OSYS < 0x07DC)) { ...legacy init... }     // 0x07DC == "Windows 2012"
+```
+
+Linux's ACPICA spoofs the Windows strings, so `OSYS` ends up high (`0x07DF`) on
+Linux too — i.e. Linux takes the *modern-Windows* branch. That matters below:
+the modern branch frequently means *"the OS/vendor driver will do it"*, and on
+Linux there is no vendor driver to pick up the slack.
+
+---
+
+## 1. Touchscreen — `\_SB.PC00.I2C2.TPL1` (`_HID "FTSC1000"`)
+
+This device **does** have a `_DSM`, but it only hands out *resources* — it never
+powers the panel. Power-up was delegated to the OS/vendor driver via the `OSYS`
+gate, which is the gap our script fills.
+
+### The `_DSM` (dispatch only)
+
+```asl
+Name (_S0W, 0x04)                       // can wake from S0 (S0ix)
+Method (_DSM, 4, Serialized)
+{
+    If ((Arg0 == HIDG)) { Return (HIDD (Arg0, Arg1, Arg2, Arg3, HID2)) }  // HID-over-I2C
+    If ((Arg0 == TP7G)) { Return (TP7D (Arg0, Arg1, Arg2, Arg3, SBFB, SBFG)) } // touch GPIO/I2C res
+    Return (Buffer (One){ 0x00 })
+}
+```
+
+Two UUIDs, both standard plumbing — **neither toggles power**:
+
+| Key | UUID | What `_DSM` does |
+|-----|------|------------------|
+| `HIDG` | `3cdff6f7-4267-4555-ad05-b30a3d8938de` (HID-over-I2C) | Fn 0 → returns support bitmap `0x03`; Fn 1 → returns `HID2` = the **HID descriptor register address** (set to `1` in `_INI`). |
+| `TP7G` | `ef87eb82-f951-46da-84ec-14871ac6f84b` | Fn 0 → `0x03`; Fn 1 → `ConcatenateResTemplate(SBFB, SBFG)` = the I²C-bus + GpioInt resources, concatenated. |
+
+```asl
+Method (HIDD, 5, Serialized) {            // shared HID-over-I2C handler
+    If ((Arg0 == HIDG)) {
+        If ((Arg2 == Zero) && (Arg1 == One)) { Return (Buffer(One){0x03}) } // funcs 0,1 supported
+        If ((Arg2 == One)) { Return (Arg4) }   // Arg4 == HID2 == descriptor reg addr
+    }
+    Return (Buffer(One){0x00})
+}
+Method (TP7D, 6, Serialized) {            // hands back I2C+GPIO resources
+    If ((Arg0 == TP7G)) {
+        If ((Arg2 == Zero) && (Arg1 == One)) { Return (Buffer(One){0x03}) }
+        If ((Arg2 == One)) { Return (ConcatenateResTemplate (Arg4, Arg5)) } // SBFB + SBFG
+    }
+    Return (Buffer(One){0x00})
+}
+```
+
+### Where power *actually* should happen — `_INI`, and why it doesn't on Linux
+
+```asl
+Method (_INI, 0, NotSerialized)
+{
+    TPGI = T1GI
+    If (CondRefOf (\_SB)) {
+        If ((OSYS < 0x07DC)) { SRXO (TPGI, One) }   // <-- GPIO power/rx enable, LEGACY-Windows ONLY
+        INT1 = GNUM (TPGI)
+        INT2 = INUM (TPGI)
+        ... SHPO (TPGI, …)                          // pad host-ownership
+    }
+    If ((TPLT == One)) { _HID = "FTSC1000"; HID2 = One; BADR = 0x38 }
+}
+Method (_STA, …) { If ((TPLT == One)) { Return (0x0F) } Return (Zero) }  // present iff TPLT==1
+```
+
+**The smoking gun:** `SRXO(TPGI, One)` — the call that drives the panel's GPIO
+rail — is gated behind `OSYS < 0x07DC`. On modern Windows (and on Linux, which
+spoofs modern Windows) that branch is **skipped**, on the assumption that the
+precise-touch/vendor driver will power the controller itself. Windows' driver
+does. Linux's generic `i2c_hid_acpi` does **not** drive vendor GPIOs, so the
+controller stays unpowered and never ACKs on I²C.
+
+→ **Our fix** (`fixes/touchscreen/`) is precisely the missing vendor step: drive
+the GPIO lines high and call the panel's `_ON`, then bind `i2c_hid_acpi`. Also
+note `_HID` is literally `"XXXX0000"` until `_INI` sets it to `"FTSC1000"` when
+`TPLT==1` — so the device is invisible until init runs, another reason a clean
+DSDT + correct init order matters. Upstream-clean would be a real
+`PowerResource`/`_PS0` on the node (it has none) so `i2c_hid` powers it itself.
+
+---
+
+## 2. Fingerprint — there is **no `_DSM`** (it's a pure USB device)
+
+The DSDT *does* contain a fingerprint node, but it's the wrong bus:
+
+```asl
+Scope (_SB.PC00.SPI1) {
+  Device (FPNT) {
+    Method (_HID, 0, …) {                 // SPI sensor menu, selected by EC byte FPTT
+      If ((FPTT == One))  { Return ("FPC1011") }
+      If ((FPTT == 0x02)) { Return ("FPC1020") }
+      If ((FPTT == 0x03)) { Return ("VFSI6101") }
+      If ((FPTT == 0x04)) { Return ("VFSI7500") }
+      If ((FPTT == 0x05)) { Return ("EGIS0300") }
+      If ((FPTT == 0x06)) { Return ("FPC1021") }
+      Return ("DUMY0000")
+    }
+    Method (_INI, …) { SHPO (GFPI, One); SHPO (GFPS, One) }   // SPI/GPIO setup
+    Method (_STA, …) { If ((FPTT != Zero) && (SPIP == One)) { Return (0x0F) } Return (Zero) }
+  }
+}
+```
+
+`FPNT` is a generic **SPI** fingerprint slot for other SKUs. On this unit
+`FPTT == 0` (the EC reports no SPI sensor) → `_HID` resolves to `"DUMY0000"` and
+`_STA` returns 0 (absent). The actual reader is **USB**:
+
+```
+/sys/bus/usb/devices/3-6 → idVendor=10a5 idProduct=9924   (FPC match-on-chip)
+```
+
+A USB device enumerates entirely from its own descriptors — **no ACPI, no
+`_DSM`, no `_PS0` involved at all.** So there was never anything to "miss" in
+firmware; the only place to fix it is the USB driver.
+
+→ **Our fix** (`fixes/fingerprint/`) is a `libfprint`/`fpcmoc` patch: register
+`10A5:9924` and trust the on-chip match for this firmware's `0x4` identity
+token. Windows simply ships FPC's signed USB driver, which already knows the id.
+
+---
+
+## 3. Embedded Controller — `\_SB.PC00.LPCB.WTEC` (`_HID "PNP0C09"`) — no `_DSM`
+
+```asl
+Device (WTEC) {
+    Name (_HID, EisaId ("PNP0C09"))      // Embedded Controller
+    Method (_CRS, …) { ... IO 0x62 ; IO 0x66 ... }     // legacy EC command/data ports
+    OperationRegion (ECF0, SystemMemory, 0xFE0B0000, 0xFF)   // <-- memory-mapped EC RAM, bank 0
+    OperationRegion (ECF1, SystemMemory, 0xFE0B0100, 0xFF)   //     bank 1
+    OperationRegion (ECF3, SystemMemory, 0xFE0B0300, 0xFF)   //     ...
+    ...
+    Field (ECF0, ByteAcc, Lock, Preserve) { EFMV,8, EFSV,8, EFTV,8, ... FPTT,8, ... }
+}
+```
+
+The EC has **no `_DSM`** — devices don't negotiate with it that way. Two access
+paths exist:
+
+- **Legacy 0x62/0x66 IO** (declared in `_CRS`) — what `ec_sys` and the kernel's
+  `acpi_ec` expose as the 256-byte EC address space. This is the space we dumped
+  and diffed.
+- **Memory-mapped banks at `0xFE0B0000 + 0x100·n`** — the same EC RAM the DSDT
+  itself reads/writes (e.g. `FPTT`, the SPI-fingerprint selector above, lives in
+  bank 0).
+
+There is no firmware method that says "fan1 RPM is here" or "charge stop % is
+here" — that mapping is **driver knowledge**, hardcoded in Huawei's Windows EC
+driver. We recovered it by diffing EC RAM:
+
+| Field | EC offset (0x62/0x66 space) |
+|-------|------------------------------|
+| fan1 RPM | `0x2C`/`0x2D` |
+| fan2 RPM | `0x2E`/`0x2F` |
+| charge start % | `0x80` |
+| charge stop % | `0x81` |
+| threshold enable flags | `0x85`, `0x87` |
+
+→ **Our fixes**: `fixes/fan/` (`honor-fmbp-hwmon` reads `0x2C–0x2F`) and
+`fixes/battery/` (thresholds via `huawei-wmi`, which flips `0x80/0x81/0x85/0x87`).
+
+---
+
+## Conclusion
+
+- **Touchscreen** — has a `_DSM`, but it only returns descriptors/resources; the
+  power step (`SRXO`) is `OSYS`-gated to legacy Windows and otherwise left to the
+  vendor driver. No `PowerResource`/`_PS0` on the node → Linux can't auto-power
+  it. *(Our GPIO `_ON` script = the missing vendor power-up.)*
+- **Fingerprint** — pure USB (`10a5:9924`); the ACPI `FPNT` node is an inactive
+  SPI slot. No `_DSM` is involved at all. *(Our libfprint patch = the missing
+  USB driver.)*
+- **EC** — no `_DSM`; register meanings are driver knowledge, recovered by RAM
+  diffing. *(Our hwmon module + WMI thresholds = the missing EC driver.)*
+
+So: no second firmware "base", nothing hidden. Windows wins out-of-the-box on a
+lenient AML interpreter, the `_OSI` Windows branch, and a stack of signed vendor
+drivers — and we've reproduced each of those through the proper Linux mechanism.
+The clean long-term fixes are upstream: a real touchscreen `PowerResource`,
+`huawei-wmi` keymap + thresholds, and the `fpcmoc` id/`0x4` handling.
+
+*Decompiled and annotated with the help of an LLM, cross-checked against the
+live `/sys/firmware/acpi/tables` dump on real hardware.*

--- a/fixes/battery/README.md
+++ b/fixes/battery/README.md
@@ -1,0 +1,28 @@
+# Battery charge thresholds
+
+Relates to issues #10 / #17.
+
+## Finding
+On this unit (BIOS 1.16, with the DSDT override applied) the charge thresholds
+exposed by `huawei-wmi` **are honoured by the EC**:
+
+```sh
+echo "60 80" | sudo tee /sys/devices/platform/huawei-wmi/charge_control_thresholds
+# or per-attribute:
+#   /sys/class/power_supply/BAT0/charge_control_start_threshold
+#   /sys/class/power_supply/BAT0/charge_control_end_threshold
+```
+
+Writing thresholds flips EC registers `0x80`/`0x81` (start/stop %) and enable
+flags `0x85`/`0x87` (confirmed by diffing EC RAM), and charging stops at the set
+ceiling. Earlier "thresholds ignored" reports may predate the DSDT fix that gets
+the EC working correctly.
+
+## Persist across reboots
+`honor-battery-thresholds.service` re-applies the limits at boot (defaults to
+60–80; edit the value to taste):
+```sh
+sudo install -Dm644 honor-battery-thresholds.service /etc/systemd/system/honor-battery-thresholds.service
+sudo systemctl enable honor-battery-thresholds.service
+```
+(`matebook-applet` also works as a GUI alternative, per issue #10.)

--- a/fixes/battery/honor-battery-thresholds.service
+++ b/fixes/battery/honor-battery-thresholds.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Restore battery charge thresholds (Honor FMB-P)
+After=systemd-modules-load.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'echo "60 80" > /sys/devices/platform/huawei-wmi/charge_control_thresholds'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/fixes/fan/Makefile
+++ b/fixes/fan/Makefile
@@ -1,0 +1,10 @@
+obj-m := honor-fmbp-hwmon.o
+
+KVERSION ?= $(shell uname -r)
+KDIR ?= /lib/modules/$(KVERSION)/build
+
+all:
+	$(MAKE) -C $(KDIR) M=$(CURDIR) modules
+
+clean:
+	$(MAKE) -C $(KDIR) M=$(CURDIR) clean

--- a/fixes/fan/README.md
+++ b/fixes/fan/README.md
@@ -1,0 +1,36 @@
+# Fan speed readout — `honor-fmbp-hwmon`
+
+Resolves issue #7 (fan RPM reporting).
+
+## What it does
+A small hwmon kernel module that exposes the two fan tachometers the EC keeps
+in its RAM, so `sensors` shows real RPMs (e.g. `fan1: 2291 RPM`, `fan2: 1989 RPM`).
+
+The fan **control** is still handled autonomously by the EC — this only adds
+read-only RPM reporting, which was previously missing entirely.
+
+## How the registers were found
+Dumping the EC RAM (`modprobe ec_sys`, read `/sys/kernel/debug/ec/ec0/io`) at
+idle vs. under a CPU stress load and diffing revealed two little-endian 16-bit
+words that scale with fan speed:
+
+| EC offset | meaning            |
+|-----------|--------------------|
+| `0x2C/0x2D` | fan 1 RPM (LE)   |
+| `0x2E/0x2F` | fan 2 RPM (LE)   |
+
+(For reference, other useful EC offsets found the same way: `0x10–0x1A` =
+temperatures in °C, `0x80/0x81` = battery charge start/stop thresholds,
+`0x85/0x87` = threshold enable flags, `0x0A` = performance-mode flag.)
+
+## Install (DKMS — survives kernel updates)
+```sh
+sudo cp -r . /usr/src/honor-fmbp-hwmon-1.0
+sudo dkms add honor-fmbp-hwmon/1.0
+sudo dkms install honor-fmbp-hwmon/1.0
+echo honor-fmbp-hwmon | sudo tee /etc/modules-load.d/honor-fmbp-hwmon.conf
+sudo modprobe honor-fmbp-hwmon
+sensors honor_fmbp-isa-0000
+```
+
+The module is DMI-gated to `HONOR / FMB-P`, so it won't load on other machines.

--- a/fixes/fan/dkms.conf
+++ b/fixes/fan/dkms.conf
@@ -1,0 +1,7 @@
+PACKAGE_NAME="honor-fmbp-hwmon"
+PACKAGE_VERSION="1.0"
+BUILT_MODULE_NAME[0]="honor-fmbp-hwmon"
+DEST_MODULE_LOCATION[0]="/updates/dkms"
+MAKE[0]="make KVERSION=$kernelver"
+CLEAN="make clean"
+AUTOINSTALL="yes"

--- a/fixes/fan/honor-fmbp-hwmon.c
+++ b/fixes/fan/honor-fmbp-hwmon.c
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * hwmon driver for Honor MagicBook 14 Pro (FMB-P) EC fan tachometers.
+ *
+ * The EC exposes two little-endian RPM words in its RAM:
+ *   0x2C/0x2D - fan 1, 0x2E/0x2F - fan 2
+ * (discovered by diffing EC RAM dumps at idle vs. under CPU load).
+ */
+
+#include <linux/module.h>
+#include <linux/hwmon.h>
+#include <linux/acpi.h>
+#include <linux/dmi.h>
+#include <linux/platform_device.h>
+
+#define FMBP_EC_FAN1_LO	0x2c
+#define FMBP_EC_FAN1_HI	0x2d
+#define FMBP_EC_FAN2_LO	0x2e
+#define FMBP_EC_FAN2_HI	0x2f
+
+static struct platform_device *fmbp_pdev;
+static struct device *fmbp_hwmon_dev;
+
+static int fmbp_read_fan(u8 lo_addr, u8 hi_addr, long *rpm)
+{
+	u8 lo, hi;
+	int ret;
+
+	ret = ec_read(lo_addr, &lo);
+	if (ret)
+		return ret;
+	ret = ec_read(hi_addr, &hi);
+	if (ret)
+		return ret;
+
+	*rpm = (hi << 8) | lo;
+	return 0;
+}
+
+static int fmbp_hwmon_read(struct device *dev, enum hwmon_sensor_types type,
+			   u32 attr, int channel, long *val)
+{
+	if (type != hwmon_fan || attr != hwmon_fan_input)
+		return -EOPNOTSUPP;
+
+	if (channel == 0)
+		return fmbp_read_fan(FMBP_EC_FAN1_LO, FMBP_EC_FAN1_HI, val);
+	if (channel == 1)
+		return fmbp_read_fan(FMBP_EC_FAN2_LO, FMBP_EC_FAN2_HI, val);
+
+	return -EOPNOTSUPP;
+}
+
+static const char * const fmbp_fan_labels[] = { "fan1", "fan2" };
+
+static int fmbp_hwmon_read_string(struct device *dev,
+				  enum hwmon_sensor_types type, u32 attr,
+				  int channel, const char **str)
+{
+	if (type != hwmon_fan || attr != hwmon_fan_label ||
+	    channel >= ARRAY_SIZE(fmbp_fan_labels))
+		return -EOPNOTSUPP;
+
+	*str = fmbp_fan_labels[channel];
+	return 0;
+}
+
+static umode_t fmbp_hwmon_is_visible(const void *data,
+				     enum hwmon_sensor_types type, u32 attr,
+				     int channel)
+{
+	return 0444;
+}
+
+static const struct hwmon_channel_info * const fmbp_hwmon_info[] = {
+	HWMON_CHANNEL_INFO(fan,
+			   HWMON_F_INPUT | HWMON_F_LABEL,
+			   HWMON_F_INPUT | HWMON_F_LABEL),
+	NULL
+};
+
+static const struct hwmon_ops fmbp_hwmon_ops = {
+	.is_visible = fmbp_hwmon_is_visible,
+	.read = fmbp_hwmon_read,
+	.read_string = fmbp_hwmon_read_string,
+};
+
+static const struct hwmon_chip_info fmbp_hwmon_chip_info = {
+	.ops = &fmbp_hwmon_ops,
+	.info = fmbp_hwmon_info,
+};
+
+static const struct dmi_system_id fmbp_dmi_table[] = {
+	{
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "HONOR"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "FMB-P"),
+		},
+	},
+	{}
+};
+MODULE_DEVICE_TABLE(dmi, fmbp_dmi_table);
+
+static int __init fmbp_hwmon_init(void)
+{
+	if (!dmi_check_system(fmbp_dmi_table))
+		return -ENODEV;
+
+	fmbp_pdev = platform_device_register_simple("honor_fmbp_hwmon", -1,
+						    NULL, 0);
+	if (IS_ERR(fmbp_pdev))
+		return PTR_ERR(fmbp_pdev);
+
+	fmbp_hwmon_dev = hwmon_device_register_with_info(&fmbp_pdev->dev,
+			"honor_fmbp", NULL, &fmbp_hwmon_chip_info, NULL);
+	if (IS_ERR(fmbp_hwmon_dev)) {
+		platform_device_unregister(fmbp_pdev);
+		return PTR_ERR(fmbp_hwmon_dev);
+	}
+
+	return 0;
+}
+
+static void __exit fmbp_hwmon_exit(void)
+{
+	hwmon_device_unregister(fmbp_hwmon_dev);
+	platform_device_unregister(fmbp_pdev);
+}
+
+module_init(fmbp_hwmon_init);
+module_exit(fmbp_hwmon_exit);
+
+MODULE_DESCRIPTION("Honor MagicBook 14 Pro (FMB-P) EC fan hwmon driver");
+MODULE_LICENSE("GPL");

--- a/fixes/fingerprint/PKGBUILD.example
+++ b/fixes/fingerprint/PKGBUILD.example
@@ -1,0 +1,34 @@
+# Maintainer: local build for Honor MagicBook 14 Pro (FMB-P)
+# libfprint with FPC 10a5:9924 added to the fpcmoc driver (sensor protocol
+# is identical to the already-supported 9524/9B24 family).
+pkgname=libfprint-fmbp
+pkgver=1.94.10
+pkgrel=1
+pkgdesc="libfprint with Honor MagicBook FMB-P fingerprint sensor (FPC 10a5:9924)"
+arch=('x86_64')
+url="https://gitlab.freedesktop.org/libfprint/libfprint"
+license=('LGPL-2.1-or-later')
+depends=('libgusb' 'nss' 'pixman' 'glib2')
+makedepends=('meson' 'ninja' 'git' 'cmake' 'glib2-devel')
+provides=("libfprint=$pkgver" 'libfprint-2.so')
+conflicts=('libfprint')
+source=("git+https://gitlab.freedesktop.org/libfprint/libfprint.git"
+        "fmbp-fpc-9924.patch")
+sha256sums=('SKIP' 'SKIP')
+
+prepare() {
+  cd libfprint
+  patch -p1 < ../fmbp-fpc-9924.patch
+}
+
+build() {
+  arch-meson libfprint build \
+    -Ddoc=false \
+    -Dintrospection=false \
+    -Dgtk-examples=false
+  meson compile -C build
+}
+
+package() {
+  meson install -C build --destdir "$pkgdir"
+}

--- a/fixes/fingerprint/README.md
+++ b/fixes/fingerprint/README.md
@@ -1,0 +1,39 @@
+# Fingerprint reader (FPC `10a5:9924`) — working enroll + verify
+
+Resolves issue #6.
+
+## Summary
+The power-button fingerprint sensor is an FPC match-on-chip device,
+`10a5:9924` ("FPC L:2407 FW:3334151"). It is **not** in upstream `libfprint`,
+but it speaks the same protocol as the already-supported `fpcmoc` family
+(`0x9524`, `0x9B24`, `0xC844`, …). Two small changes make it work:
+
+1. **Register the USB id** `10A5:9924` in the `fpcmoc` driver's id table.
+2. **Handle this firmware's identify response.** On a match it returns an
+   opaque, stable, per-enrollment token with `identity_type == 0x4` instead of
+   echoing the bound identity, so libfprint's host-side `fp_print_equal()` check
+   fails and every verify returns *no-match*. Since the match is performed on
+   the secure element (status `0` + a valid token is only returned for a genuine
+   enrolled finger), the driver trusts that decision for the `0x4` form.
+   Verified behaviour: enrolled finger matches reliably; different fingers are
+   rejected (the chip returns an empty identity for non-matches).
+
+See `fmbp-fpc-9924.patch` (against libfprint 1.94.x). `PKGBUILD.example` shows
+how it was packaged on Arch/CachyOS.
+
+## Build
+```sh
+git clone https://gitlab.freedesktop.org/libfprint/libfprint
+cd libfprint && patch -p1 < /path/to/fmbp-fpc-9924.patch
+meson setup build -Ddrivers=fpcmoc && ninja -C build
+# install, then enroll:  fprintd-enroll -f right-index-finger
+```
+
+## Caveats
+- Match reliability depends on enrollment quality (consistent, centred, firm
+  placement). Enroll a single finger carefully for best results.
+- Because the host can't reconstruct the opaque token, multi-finger *identify*
+  can't tell which enrolled finger matched (fine for login/verify, which only
+  asks "is this finger enrolled?").
+- This is a pragmatic driver-level workaround; upstreaming would ideally decode
+  the `0x4` identity format properly.

--- a/fixes/fingerprint/fmbp-fpc-9924.patch
+++ b/fixes/fingerprint/fmbp-fpc-9924.patch
@@ -1,0 +1,47 @@
+diff --git a/libfprint/drivers/fpcmoc/fpc.c b/libfprint/drivers/fpcmoc/fpc.c
+index 65fa582..3754efa 100644
+--- a/libfprint/drivers/fpcmoc/fpc.c
++++ b/libfprint/drivers/fpcmoc/fpc.c
+@@ -70,6 +70,7 @@ static const FpIdEntry id_table[] = {
+   { .vid = 0x10A5,  .pid = 0xD805,  },
+   { .vid = 0x10A5,  .pid = 0xD205,  },
+   { .vid = 0x10A5,  .pid = 0x9524,  },
++  { .vid = 0x10A5,  .pid = 0x9924,  },
+   { .vid = 0x10A5,  .pid = 0x9544,  },
+   { .vid = 0x10A5,  .pid = 0xC844,  },
+   { .vid = 0x10A5,  .pid = 0x9B24,  },
+@@ -1218,8 +1219,12 @@ fpc_verify_cb (FpiDeviceFpcMoc *self,
+   g_assert (current_action == FPI_DEVICE_ACTION_VERIFY ||
+             current_action == FPI_DEVICE_ACTION_IDENTIFY);
+ 
++  /* Some newer FPC sensors (e.g. 10a5:9924 FW 3334151) report a matched
++   * identity with type 0x4 and a trailing NUL byte appended, instead of
++   * the bound FPC_IDENTITY_TYPE_RESERVED form. Accept both. */
+   if ((presp->status == 0) && (presp->subfactor == FPC_SUBTYPE_RESERVED) &&
+-      (presp->identity_type == FPC_IDENTITY_TYPE_RESERVED) &&
++      (presp->identity_type == FPC_IDENTITY_TYPE_RESERVED ||
++       presp->identity_type == 0x4) &&
+       (presp->identity_size <= SECURITY_MAX_SID_SIZE))
+     {
+       FpPrint *match = NULL;
+@@ -1258,6 +1263,20 @@ fpc_verify_cb (FpiDeviceFpcMoc *self,
+             }
+         }
+ 
++      /* Match-on-chip firmware variant (e.g. 10a5:9924, FW 3334151): instead
++       * of echoing the bound identity, the sensor returns an opaque, stable,
++       * per-enrollment token (identity_type 0x4) that cannot be reconstructed
++       * on the host. The secure element has already performed the biometric
++       * match against its own database (status == 0), so trust that decision:
++       * for VERIFY report the single candidate, for IDENTIFY map to the first
++       * enrolled print (the device confirms a genuine enrolled finger but the
++       * opaque token does not let us disambiguate between several). */
++      if (!found && presp->identity_type == 0x4 && templates->len > 0)
++        {
++          print = g_ptr_array_index (templates, 0);
++          found = TRUE;
++        }
++
+       if (found)
+         {
+           if (current_action == FPI_DEVICE_ACTION_VERIFY)

--- a/fixes/fn-keys/61-honor-fmbp-keyboard.hwdb
+++ b/fixes/fn-keys/61-honor-fmbp-keyboard.hwdb
@@ -1,0 +1,4 @@
+# Honor MagicBook 14 Pro (FMB-P): the EC sends scancode e078 alongside Fn
+# hotkey presses; it carries no meaning — map to unknown to silence dmesg.
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svnHONOR*:pn*:*
+ KEYBOARD_KEY_e078=unknown

--- a/fixes/fn-keys/README.md
+++ b/fixes/fn-keys/README.md
@@ -1,0 +1,41 @@
+# Fn keys — patched `huawei-wmi`
+
+Resolves issue #4.
+
+## What works after this
+Maps the FMB-P-specific WMI hotkey codes that the in-tree `huawei-wmi` driver
+doesn't know, so the previously-dead Fn keys emit proper keycodes:
+
+| WMI code | key |
+|----------|-----|
+| `0x283` / `0x2a3` | touchpad toggle on/off (F-row) |
+| `0x288` | camera access toggle |
+| `0x2a0` / `0x2a1` / `0x2a6` | performance-mode switch (Fn+P) |
+| `0x2a7` | refresh-rate toggle (Fn+R) |
+| `0x2b1`–`0x2b4` | keyboard-backlight level keys |
+| `0x2e0` / `0x2e1` | camera module enable/disable |
+| `0x2e5` / `0x2e6` | EC auto-backlight notifications (ignored) |
+
+The keymap additions are based on the work in
+[aymanbagabas/Huawei-WMI#93](https://github.com/aymanbagabas/Huawei-WMI/pull/93)
+adapted to the in-kernel driver.
+
+`61-honor-fmbp-keyboard.hwdb` additionally silences a meaningless `e078` atkbd
+scancode the EC emits alongside hotkey presses (stops the
+`atkbd: Unknown key pressed` dmesg spam).
+
+## Install (DKMS against the in-tree module)
+```sh
+# Fetch the matching in-tree driver source for your kernel, apply the patch,
+# and build it as a DKMS module that overrides the stock huawei-wmi.
+curl -L "https://git.kernel.org/.../drivers/platform/x86/huawei-wmi.c?h=v<your-kver>" -o huawei-wmi.c
+patch huawei-wmi.c < huawei-wmi-fmbp.patch
+# package as DKMS (BUILT_MODULE_NAME=huawei-wmi, DEST=/updates/dkms) and install.
+
+# hwdb:
+sudo install -Dm644 61-honor-fmbp-keyboard.hwdb /etc/udev/hwdb.d/61-honor-fmbp-keyboard.hwdb
+sudo systemd-hwdb update && sudo udevadm trigger
+```
+
+Ideally these mappings land upstream in `huawei-wmi` so no out-of-tree module is
+needed; the patch here is provided for people who want them working today.

--- a/fixes/fn-keys/huawei-wmi-fmbp.patch
+++ b/fixes/fn-keys/huawei-wmi-fmbp.patch
@@ -1,0 +1,38 @@
+--- /tmp/huawei-wmi-orig.c	2026-06-12 08:57:39.039747739 +0200
++++ /tmp/huawei-wmi-mod.c	2026-06-12 08:57:39.046642836 +0200
+@@ -78,6 +78,11 @@
+ 	{ KE_KEY,    0x285, { KEY_VOLUMEDOWN } },
+ 	{ KE_KEY,    0x286, { KEY_VOLUMEUP } },
+ 	{ KE_KEY,    0x287, { KEY_MICMUTE } },
++	// HONOR FMB-P touchpad toggle (F3)
++	{ KE_KEY,    0x283, { KEY_TOUCHPAD_ON } },
++	{ KE_KEY,    0x2a3, { KEY_TOUCHPAD_OFF } },
++	// HONOR FMB-P camera access toggle (F8)
++	{ KE_KEY,    0x288, { KEY_CAMERA_ACCESS_TOGGLE } },
+ 	{ KE_KEY,    0x289, { KEY_WLAN } },
+ 	// Huawei |M| key
+ 	{ KE_KEY,    0x28a, { KEY_CONFIG } },
+@@ -89,6 +94,23 @@
+ 	{ KE_IGNORE, 0x293, { KEY_KBDILLUMTOGGLE } },
+ 	{ KE_IGNORE, 0x294, { KEY_KBDILLUMUP } },
+ 	{ KE_IGNORE, 0x295, { KEY_KBDILLUMUP } },
++	// Keyboard backlight levels (space bar cycle on some models)
++	{ KE_KEY,    0x2b1, { KEY_KBDILLUMDOWN } },
++	{ KE_KEY,    0x2b2, { KEY_KBDILLUMDOWN } },
++	{ KE_KEY,    0x2b3, { KEY_KBDILLUMUP } },
++	{ KE_KEY,    0x2b4, { KEY_KBDILLUMTOGGLE } },
++	// Power/performance mode switch (Fn+P)
++	{ KE_KEY,    0x2a0, { KEY_PROG1 } },
++	{ KE_KEY,    0x2a1, { KEY_PROG1 } },
++	{ KE_KEY,    0x2a6, { KEY_PROG1 } },
++	// Refresh rate toggle (Fn+R)
++	{ KE_KEY,    0x2a7, { KEY_REFRESH_RATE_TOGGLE } },
++	// Camera module slot
++	{ KE_KEY,    0x2e0, { KEY_CAMERA_ACCESS_ENABLE } },
++	{ KE_KEY,    0x2e1, { KEY_CAMERA_ACCESS_DISABLE } },
++	// HONOR FMB-P EC notifications (kbd backlight auto on/off), ignore
++	{ KE_IGNORE, 0x2e5, { KEY_RESERVED } },
++	{ KE_IGNORE, 0x2e6, { KEY_RESERVED } },
+ 	// Ignore Ambient Light Sensoring
+ 	{ KE_KEY,    0x2c1, { KEY_RESERVED } },
+ 	{ KE_END,	 0 }

--- a/fixes/touchscreen/README.md
+++ b/fixes/touchscreen/README.md
@@ -1,0 +1,48 @@
+# Touchscreen (FocalTech FTSC1000) — working fix
+
+Resolves issue #5 / #20.
+
+## Root cause
+The BIOS attaches the touchscreen's power resource (`PTPL`) to the wrong I2C
+scope, so the FocalTech `FTSC1000` panel on `\_SB.PC00.I2C2.TPL1` is never
+powered or taken out of reset. Linux enumerates the ACPI device but
+`i2c_hid_acpi` can't talk to it (`i2ctransfer` to `0x38` returns `Remote I/O
+error`). The panel's Power-Enable and Reset lines are GPIOs that stay low.
+
+## Fix
+Drive the two GPIO lines high, call the (misplaced) `_ON` power method, then
+bind the HID driver. A bogus secondary HID keyboard interface
+(`FTSC1000:00 2808:5662 UNKNOWN`) that the firmware also exposes is inhibited to
+stop phantom key events / mic-LED flicker.
+
+GPIO mapping on the Intel `INTC105E` controller (gpiochip0):
+- line **108** (`GPP_A_12`) = touch power-enable → drive high
+- line **130** (`GPP_E_2`)  = touch reset → drive high (release reset)
+
+## Install
+```sh
+# dependencies
+sudo pacman -S --needed acpi_call-dkms libgpiod   # Arch/CachyOS
+# (Fedora: acpi_call-dkms from rpmfusion/copr; Debian: acpi-call-dkms + gpiod)
+
+sudo install -Dm755 honor-touchscreen-on.sh /usr/local/sbin/honor-touchscreen-on.sh
+sudo install -Dm644 honor-touchscreen.service /etc/systemd/system/honor-touchscreen.service
+sudo install -Dm755 honor-touchscreen.sleep-hook /usr/lib/systemd/system-sleep/honor-touchscreen
+echo acpi_call | sudo tee /etc/modules-load.d/acpi_call.conf
+sudo systemctl daemon-reload
+sudo systemctl enable --now honor-touchscreen.service
+```
+
+Add this udev rule (append to `99-ignore-touchpad-device.rules`) so the bogus
+HID interface is inhibited automatically:
+```
+SUBSYSTEM=="input", ATTRS{name}=="FTSC1000:00 2808:5662 UNKNOWN", RUN+="/bin/sh -c 'echo 1 > /sys$env{DEVPATH}/../inhibited'"
+```
+
+## Notes
+- The GPIO line numbers come from `gpioinfo` and may differ if your firmware
+  enumerates the controller differently — verify with `gpioinfo gpiochip0`
+  (look for the two `output` lines around 108/130).
+- A cleaner long-term fix would patch the DSDT to attach the power resource to
+  the correct scope and/or add `_PS0`/`_PS3`; this script-based approach avoids
+  shipping another DSDT override.

--- a/fixes/touchscreen/honor-touchscreen-on.sh
+++ b/fixes/touchscreen/honor-touchscreen-on.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Honor MagicBook 14 Pro (FMB-P): the BIOS wires the touchscreen's power
+# resource (PTPL) to the wrong I2C scope, so the FocalTech FTSC1000 panel
+# is never powered/reset. Drive its power-enable (GPIO 108 / GPP_A_12) and
+# reset (GPIO 130 / GPP_E_2) lines high, call the misplaced _ON method,
+# then bind the i2c-hid driver.
+# Ref: https://github.com/colorcube/Linux-on-Honor-Magicbook-14-Pro/issues/5
+
+modprobe acpi_call 2>/dev/null || true
+
+gpioset -c gpiochip0 108=1 130=1 &
+GPIOPID=$!
+sleep 0.5
+
+if [ -w /proc/acpi/call ]; then
+    echo '\_SB.PC00.I2C5.PTPL._ON' > /proc/acpi/call || true
+fi
+sleep 0.5
+
+if [ ! -e /sys/bus/i2c/drivers/i2c_hid_acpi/i2c-FTSC1000:00 ]; then
+    echo i2c-FTSC1000:00 > /sys/bus/i2c/drivers/i2c_hid_acpi/bind 2>/dev/null || true
+fi
+sleep 0.5
+kill $GPIOPID 2>/dev/null
+
+# The bogus secondary keyboard interface is inhibited by
+# /etc/udev/rules.d/99-ignore-touchpad-device.rules
+exit 0

--- a/fixes/touchscreen/honor-touchscreen.service
+++ b/fixes/touchscreen/honor-touchscreen.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Power on Honor MagicBook FMB-P touchscreen (BIOS PTPL bug workaround)
+After=systemd-modules-load.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/honor-touchscreen-on.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/fixes/touchscreen/honor-touchscreen.sleep-hook
+++ b/fixes/touchscreen/honor-touchscreen.sleep-hook
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Re-power the FMB-P touchscreen after suspend (panel power is lost in sleep).
+case "$1" in
+    post)
+        /usr/local/sbin/honor-touchscreen-on.sh
+        ;;
+esac
+exit 0


### PR DESCRIPTION
Hi — thanks for maintaining this repo, it got my FMB-P running. I worked through
most of the remaining open issues and wanted to contribute the fixes and findings
back.

Tested on a **global FMB-P, BIOS 1.16, Core Ultra 9 285H (Arrow Lake-H)**,
CachyOS, kernel 7.0 (and 6.18 LTS), with the denis-bb patched DSDT applied.

## New `fixes/` directory (each with its own README + install steps)

- **Touchscreen** (FocalTech FTSC1000) — issue #5/#20. The BIOS wires the panel's
  power resource to the wrong I2C scope; driving GPIO 108 (power) + 130 (reset)
  high, calling the `_ON` method via `acpi_call`, and binding `i2c_hid_acpi`
  makes it work. Includes a service + sleep hook + the inhibit rule for the
  bogus secondary HID interface.
- **Fn keys** — issue #4. `huawei-wmi` keymap patch for the FMB-P hotkey codes
  (touchpad toggle, camera, Fn+P, Fn+R, kbd-backlight levels) plus a hwdb entry
  to silence the `e078` atkbd spam.
- **Fan speed readout** — issue #7. `honor-fmbp-hwmon`, a small DMI-gated hwmon
  module that exposes the EC fan tachometers (found by diffing EC RAM); `sensors`
  now shows RPM.
- **Fingerprint** (FPC `10a5:9924`) — issue #6. libfprint `fpcmoc` patch that
  registers the id and handles this firmware's opaque on-chip-match identity
  form. Enroll + verify work; wrong fingers are rejected.
- **Battery charge thresholds** — issue #10/#17. They're honoured by the EC on
  1.16 (with the DSDT fix); included a persist service.

## README updates
Moved touchscreen / Fn keys / fan / battery / caps+mic LED into "works with
tweaks", and noted performance profiles via `power-profiles-daemon` and working
hibernate / suspend-then-hibernate.

## Findings (hardware/firmware limits, not fixable in Linux)
- **No S3 deep sleep.** `\_S3` exists in the DSDT but is gated behind
  `Name (SS3, Zero)` which is never set. Forcing `SS3 = One` *does* register S3,
  but entering it hard-freezes the machine. Arrow Lake-H is S0ix-only and
  **Windows has no S3 on this platform either** — use hibernate for low standby
  drain.
- **No IR camera / face unlock** on the 2025 model (plain RGB webcam; the strip
  by the lens only looks like IR).

Everything here is "works for me on real hardware". The right long-term home for
several of these is upstream (huawei-wmi keymap, libfprint id + 0x4 identity
handling, a proper touchscreen DSDT power resource) — happy to adjust structure,
split this up, or move things into issues/wiki instead of code if you'd prefer,
since I know the repo is meant to be information-first.

*Disclosure: these fixes and notes were developed and documented with the help
of an LLM, then validated on the actual laptop.*